### PR TITLE
docs: Add comment to improve readability of string.uuid

### DIFF
--- a/src/modules/string/index.ts
+++ b/src/modules/string/index.ts
@@ -426,6 +426,9 @@ export class StringModule {
   /**
    * Returns a UUID v4 ([Universally Unique Identifier](https://en.wikipedia.org/wiki/Universally_unique_identifier)).
    *
+   * A version 4 UUID is randomly generated. As in other UUIDs, 4 bits are used to indicate version 4, and 2 or 3 bits to indicate
+   * the variant. For more information please see the version 4 section of the linked wiki. 
+   *
    * @example
    * faker.string.uuid() // '4136cd0b-d90b-4af7-b485-5d1ded8db252'
    *


### PR DESCRIPTION
Added a comment clarifying the random generation of the v4 UUID string as per the suggestions of the Faker dev team.
